### PR TITLE
Fix cav_msgs cmakelists and package xml for j2735 deps

### DIFF
--- a/cav_msgs/CMakeLists.txt
+++ b/cav_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   std_msgs
   geometry_msgs
+  j2735_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -129,7 +130,7 @@ generate_messages(
 catkin_package(
  # INCLUDE_DIRS include
 #  LIBRARIES cav_msgs
- CATKIN_DEPENDS message_runtime std_msgs geometry_msgs
+ CATKIN_DEPENDS message_runtime std_msgs geometry_msgs j2735_msgs
 #  DEPENDS system_lib
 )
 

--- a/cav_msgs/package.xml
+++ b/cav_msgs/package.xml
@@ -64,7 +64,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
-  <build_depend>j2735_msgs</build_depend>
+  <run_depend>j2735_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Sometimes the build order will cause cav_msgs to build before j2735_msgs because the dependency was not properly linked. This PR resolves this in the Package.xml and CMakeLists.txt files of cav_msgs. The messages now build correctly. 

This should resolve issue #9 