### PR TITLE
Feature/update driver status for carma 3

### DIFF
--- a/cav_msgs/msg/DriverStatus.msg
+++ b/cav_msgs/msg/DriverStatus.msg
@@ -21,7 +21,7 @@ uint8  FAULT=3
 # These are the possible categories - at least one must be true
 bool    can
 bool    radar
-bool    gps
+bool    gnss
 bool    lidar
 bool    roadway_sensor
 bool    comms

--- a/cav_msgs/msg/DriverStatus.msg
+++ b/cav_msgs/msg/DriverStatus.msg
@@ -19,13 +19,13 @@ uint8  FAULT=3
 #					<other values reserved for future expansion>
 
 # These are the possible categories - at least one must be true
-bool    can_bus
-bool    sensor
-bool    position
+bool    can
+bool    radar
 bool    gps
+bool    lidar
+bool    roadway_sensor
 bool    comms
-bool    lon_controller
-bool    lat_controller
+bool    controller
 bool    camera
 bool    imu
 


### PR DESCRIPTION
This PR updates the DriverStatus message to support the new driver types defined for carma 3. 
This also breaks backward compatibility with carma 2 as many of the drivers have their names changed. 