### PR TITLE
Update Plugin.msg

### DIFF
--- a/cav_msgs/msg/Plugin.msg
+++ b/cav_msgs/msg/Plugin.msg
@@ -9,12 +9,20 @@
 
 # The string name identifier for the plugin
 string name
-# The strin version identifier for the plugin
-string versionId
-# Whether or not the plugin is currently available to generate a trajectory
-bool available
-bool activated
 
-# Whether or not the plugin is required for operation of the system
-# Required plugins may not be deactivated
-bool required
+# The string version identifier for the plugin
+string versionId
+
+# The usage type for the plugin
+uint8 type
+uint8 UNKNOWN = 0
+uint8 STRATEGIC = 1
+uint8 TACTICAL = 2
+uint8 CONTROL = 3
+
+# Whether or not the plugin is currently available to generate a trajectory
+# Availability should be determined by plugin itself
+bool available
+
+# Whether or not the plugin is activated by user
+bool activated


### PR DESCRIPTION
The ```required``` field is removed because it is not the information which should be passed from plugin node to the manager node. Plugin manger node should have the ability to identify required plugins.