### PR TITLE
TrailerAngleMsg

### DIFF
--- a/cav_msgs/msg/TrailerAngle.msg
+++ b/cav_msgs/msg/TrailerAngle.msg
@@ -7,7 +7,7 @@
 # @version 0.1
 #
 
-Header header  # timestamp in the header is the time the sensor returned the angle reading
+std_msgs/Header header  # timestamp in the header is the time the sensor returned the angle reading
 
-Float64 angle #trailer angle in raidans
+float64 angle #trailer angle in raidans
 

--- a/cav_msgs/msg/TrailerAngle.msg
+++ b/cav_msgs/msg/TrailerAngle.msg
@@ -9,5 +9,5 @@
 
 std_msgs/Header header  # timestamp in the header is the time the sensor returned the angle reading
 
-float64 angle #trailer angle in raidans
+float64 angle #trailer angle in raidans. Note if the sensor 1 is mounted on the left and sensor 2 is mounted on the right. Then the left turn will produce negative radians whereas the right turn will produce positive radians. If sensor placement are swapped, the signs become opposite to previous setup.
 

--- a/cav_msgs/msg/TrailerAngle.msg
+++ b/cav_msgs/msg/TrailerAngle.msg
@@ -1,0 +1,13 @@
+#
+# Trailer Angle Message
+# 
+# This message gives the truck trailer angle in radians
+#
+# @author Aswath Suresh
+# @version 0.1
+#
+
+Header header  # timestamp in the header is the time the sensor returned the angle reading
+
+Float64 angle #trailer angle in raidans
+


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Trailer Angle custom message addition for header inclusion.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The trailer angle reported by the CARMAGarminLidarLiteV3DriverWrapper is published as an std_msgs/Float64 message type. It is difficult to use this message type reliably as it does not contain a timestamp which can be used for transform lookups. It should be updated to use a message type containing a header.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.