### PR TITLE
Add speed_limit field to route_state message

### DIFF
--- a/cav_msgs/msg/RouteState.msg
+++ b/cav_msgs/msg/RouteState.msg
@@ -34,3 +34,6 @@ float64 lanelet_downtrack
 
 # Current host vehicle lane index
 int64 lanelet_id
+
+# Current speed limit on current lanelet
+float64 speed_limit

--- a/cav_msgs/msg/RouteState.msg
+++ b/cav_msgs/msg/RouteState.msg
@@ -23,17 +23,17 @@ uint8 SELECTION=1
 uint8 ROUTING=2
 uint8 FOLLOWING=3
 
-# Cross-track distance of vehicle along route
+# Cross-track distance of vehicle along route in meters
 float64 cross_track
 
-# Down-track distance of vehicle along route
+# Down-track distance of vehicle along route in meters
 float64 down_track
 
-# Down-track distance of vehicle along the current lanelet
+# Down-track distance of vehicle along the current lanelet in meters
 float64 lanelet_downtrack
 
 # Current host vehicle lane index
 int64 lanelet_id
 
-# Current speed limit on current lanelet
+# Current speed limit on current lanelet in m/s
 float64 speed_limit


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds a current speed limit field to the RouteState message which can be used by the UI for display. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Supports https://github.com/usdot-fhwa-stol/CARMAPlatform/issues/592
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ensure UI has also information it needs for user display
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build completes
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.